### PR TITLE
Load categories from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ be served on GitHub Pages or any static web host.
 
 ## Running
 
-Open `webapp/index.html` in a browser. Ideas entered are stored in local
-storage and will persist for future visits on the same browser.
+Open `webapp/index.html` in a browser. Ideas entered are stored in the
+browser's local storage and will persist for future visits on the same
+browser.
 
-The prototype demonstrates the basic idea submission workflow with categories
-and listing of submitted ideas.
+Idea categories are loaded from `webapp/data/categories.json`. To add or
+modify categories, edit that file and refresh the page.
+
+The prototype demonstrates the basic idea submission workflow with a category
+selector and listing of submitted ideas.

--- a/webapp/data/categories.json
+++ b/webapp/data/categories.json
@@ -1,0 +1,6 @@
+[
+  "General",
+  "UI",
+  "Process",
+  "Cost Reduction"
+]

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -17,6 +17,7 @@
         <textarea id="idea-description" required></textarea>
       </label>
       <label>Category
+        <!-- Categories are loaded from data/categories.json -->
         <select id="idea-category"></select>
       </label>
       <button type="submit">Submit Idea</button>

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -1,8 +1,9 @@
-const categories = ['General', 'UI', 'Process', 'Cost Reduction'];
+let categories = [];
 let ideas = JSON.parse(localStorage.getItem('ideas') || '[]');
 
 function populateCategories() {
   const select = document.getElementById('idea-category');
+  select.innerHTML = '';
   categories.forEach(cat => {
     const option = document.createElement('option');
     option.value = cat;
@@ -41,5 +42,15 @@ function addIdea(event) {
 
 document.getElementById('idea-form').addEventListener('submit', addIdea);
 
-populateCategories();
+function loadCategories() {
+  fetch('data/categories.json')
+    .then(res => res.json())
+    .then(data => {
+      categories = data;
+      populateCategories();
+    })
+    .catch(err => console.error('Failed to load categories', err));
+}
+
+loadCategories();
 renderIdeas();


### PR DESCRIPTION
## Summary
- load idea categories from `data/categories.json`
- update README to reference categories file
- add hint in form to clarify where categories come from

## Testing
- `python3 -m http.server 8000 -d webapp`

------
https://chatgpt.com/codex/tasks/task_e_68474a02d34483329a5d239c166977ad