### PR TITLE
Add GI2MO data model and filtering UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@ Idea categories are loaded from `webapp/data/categories.json`. To add or
 modify categories, edit that file and refresh the page.
 
 The prototype demonstrates the basic idea submission workflow with a category
-selector and listing of submitted ideas.
+selector and listing of submitted ideas. Ideas can be filtered by category,
+status or searched by keywords using the controls above the list.

--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -5,3 +5,12 @@ input, textarea, select { width: 100%; padding: 0.5em; margin-top: 0.5em; }
 button { padding: 0.5em 1em; }
 .idea-item { border: 1px solid #ccc; padding: 1em; margin-bottom: 1em; }
 .idea-item h3 { margin-top: 0; }
+#filter-section label {
+  display: inline-block;
+  margin-right: 1em;
+}
+#filter-section input[type="text"],
+#filter-section select {
+  width: auto;
+  min-width: 150px;
+}

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -23,11 +23,29 @@
       <button type="submit">Submit Idea</button>
     </form>
   </section>
+  <section id="filter-section">
+    <h2>Browse Ideas</h2>
+    <label>Search
+      <input type="text" id="filter-search" placeholder="Search ideas">
+    </label>
+    <label>Category
+      <select id="filter-category">
+        <option value="">All</option>
+      </select>
+    </label>
+    <label>Status
+      <select id="filter-status">
+        <option value="">All</option>
+      </select>
+    </label>
+  </section>
   <section id="ideas-section">
     <h2>Ideas</h2>
     <ul id="ideas-list"></ul>
   </section>
 
+  <script src="js/ontology.js"></script>
+  <script src="js/models.js"></script>
   <script src="js/app.js"></script>
 </body>
 </html>

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -1,14 +1,33 @@
 let categories = [];
 let ideas = JSON.parse(localStorage.getItem('ideas') || '[]');
+const statuses = Object.values(IdeaStatus);
 
 function populateCategories() {
-  const select = document.getElementById('idea-category');
-  select.innerHTML = '';
+  const ideaSelect = document.getElementById('idea-category');
+  ideaSelect.innerHTML = '';
+  const filterSelect = document.getElementById('filter-category');
+  filterSelect.innerHTML = '<option value="">All</option>';
   categories.forEach(cat => {
+    const option1 = document.createElement('option');
+    option1.value = cat;
+    option1.textContent = cat;
+    ideaSelect.appendChild(option1);
+
+    const option2 = document.createElement('option');
+    option2.value = cat;
+    option2.textContent = cat;
+    filterSelect.appendChild(option2);
+  });
+}
+
+function populateStatuses() {
+  const filterSelect = document.getElementById('filter-status');
+  filterSelect.innerHTML = '<option value="">All</option>';
+  statuses.forEach(st => {
     const option = document.createElement('option');
-    option.value = cat;
-    option.textContent = cat;
-    select.appendChild(option);
+    option.value = st;
+    option.textContent = st;
+    filterSelect.appendChild(option);
   });
 }
 
@@ -16,13 +35,14 @@ function saveIdeas() {
   localStorage.setItem('ideas', JSON.stringify(ideas));
 }
 
-function renderIdeas() {
+function renderIdeas(data = ideas) {
   const list = document.getElementById('ideas-list');
   list.innerHTML = '';
-  ideas.forEach((idea, index) => {
+  data.forEach((idea) => {
     const li = document.createElement('li');
     li.className = 'idea-item';
-    li.innerHTML = `<h3>${idea.title}</h3><p>${idea.description}</p><p><strong>Category:</strong> ${idea.category}</p>`;
+    const snippet = idea.description.length > 120 ? idea.description.slice(0, 117) + '...' : idea.description;
+    li.innerHTML = `<h3>${idea.title}</h3><p>${snippet}</p><p><strong>Category:</strong> ${idea.category}</p><p><strong>Status:</strong> ${idea.status}</p>`;
     list.appendChild(li);
   });
 }
@@ -33,14 +53,30 @@ function addIdea(event) {
   const description = document.getElementById('idea-description').value.trim();
   const category = document.getElementById('idea-category').value;
   if (!title || !description) return;
-  const newIdea = { title, description, category, status: 'Submitted', created: new Date().toISOString() };
+  const newIdea = new Idea(title, description, category);
   ideas.push(newIdea);
   saveIdeas();
-  renderIdeas();
+  filterIdeas();
   event.target.reset();
 }
 
+function filterIdeas() {
+  const search = document.getElementById('filter-search').value.toLowerCase();
+  const cat = document.getElementById('filter-category').value;
+  const stat = document.getElementById('filter-status').value;
+  const filtered = ideas.filter(idea => {
+    const matchSearch = !search || idea.title.toLowerCase().includes(search) || idea.description.toLowerCase().includes(search);
+    const matchCat = !cat || idea.category === cat;
+    const matchStatus = !stat || idea.status === stat;
+    return matchSearch && matchCat && matchStatus;
+  });
+  renderIdeas(filtered);
+}
+
 document.getElementById('idea-form').addEventListener('submit', addIdea);
+document.getElementById('filter-search').addEventListener('input', filterIdeas);
+document.getElementById('filter-category').addEventListener('change', filterIdeas);
+document.getElementById('filter-status').addEventListener('change', filterIdeas);
 
 function loadCategories() {
   fetch('data/categories.json')
@@ -48,9 +84,11 @@ function loadCategories() {
     .then(data => {
       categories = data;
       populateCategories();
+      filterIdeas();
     })
     .catch(err => console.error('Failed to load categories', err));
 }
 
 loadCategories();
-renderIdeas();
+populateStatuses();
+filterIdeas();

--- a/webapp/js/models.js
+++ b/webapp/js/models.js
@@ -1,0 +1,43 @@
+const IdeaStatus = {
+  SUBMITTED: 'Submitted',
+  IN_REVIEW: 'In Review',
+  IMPLEMENTED: 'Implemented'
+};
+
+class Idea {
+  constructor(title, description, category, status = IdeaStatus.SUBMITTED) {
+    this['@type'] = GI2MO.Idea;
+    this.title = title;
+    this.description = description;
+    this.category = category;
+    this.status = status;
+    this.created = new Date().toISOString();
+  }
+}
+
+class IdeaContest {
+  constructor(title, description, startDate, endDate) {
+    this['@type'] = GI2MO.IdeaContest;
+    this.title = title;
+    this.description = description;
+    this.startDate = startDate;
+    this.endDate = endDate;
+  }
+}
+
+class Review {
+  constructor(text, score, author) {
+    this['@type'] = GI2MO.Review;
+    this.text = text;
+    this.score = score;
+    this.author = author;
+    this.created = new Date().toISOString();
+  }
+}
+
+class Project {
+  constructor(name) {
+    this['@type'] = GI2MO.Project;
+    this.name = name;
+  }
+}

--- a/webapp/js/ontology.js
+++ b/webapp/js/ontology.js
@@ -1,0 +1,7 @@
+const GI2MO = {
+  Idea: 'http://purl.org/gi2mo/ns#Idea',
+  IdeaStatus: 'http://purl.org/gi2mo/ns#IdeaStatus',
+  IdeaContest: 'http://purl.org/gi2mo/ns#IdeaContest',
+  Review: 'http://purl.org/gi2mo/ns#Review',
+  Project: 'http://usefulinc.com/ns/doap#Project'
+};


### PR DESCRIPTION
## Summary
- add lightweight ontology definitions and JS data models
- expand HTML with search and filter controls
- support filtering by category and status with dynamic lists
- show idea snippets and status in the list
- document new filtering features in README

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68475006217c8332b4683482535eb0f3