### PR TITLE
Integrate ontology enumerations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gi2mo-tools",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@xmldom/xmldom": "^0.8.8"
+  }
+}

--- a/scripts/generate_statuses.cjs
+++ b/scripts/generate_statuses.cjs
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const { DOMParser } = require('@xmldom/xmldom');
+
+const owlPath = 'Innovation0_gi2mo.owl';
+const xml = fs.readFileSync(owlPath, 'utf8');
+const doc = new DOMParser().parseFromString(xml, 'application/xml');
+
+function extractIds(tagName) {
+  return Array.from(doc.getElementsByTagName(tagName)).map(el => el.getAttribute('rdf:ID')).filter(Boolean);
+}
+
+const ideaStatuses = extractIds('gi2mo:IdeaStatus');
+const contestStatuses = extractIds('gi2mo:IdeaContestStatus');
+const accessTypes = extractIds('gi2mo:AccessType');
+
+fs.writeFileSync('webapp/data/statuses.json', JSON.stringify({ideaStatuses, contestStatuses, accessTypes}, null, 2));
+console.log('Generated webapp/data/statuses.json');

--- a/webapp/data/categories.json
+++ b/webapp/data/categories.json
@@ -1,6 +1,8 @@
 [
   "General",
-  "UI",
-  "Process",
-  "Cost Reduction"
+  "UI Improvements",
+  "Process Innovation",
+  "Cost Reduction",
+  "Customer Experience",
+  "AI"
 ]

--- a/webapp/data/statuses.json
+++ b/webapp/data/statuses.json
@@ -1,0 +1,21 @@
+{
+  "ideaStatuses": [
+    "Implemented",
+    "Rejected",
+    "PartialyImplemented",
+    "UnderReview",
+    "Accepted",
+    "Deployed",
+    "AlreadyExists",
+    "Draft"
+  ],
+  "contestStatuses": [
+    "Closed",
+    "PendingReviews",
+    "Active"
+  ],
+  "accessTypes": [
+    "WriteAccess",
+    "ReadAccess"
+  ]
+}

--- a/webapp/js/app.js
+++ b/webapp/js/app.js
@@ -1,6 +1,6 @@
 let categories = [];
+let statuses = [];
 let ideas = JSON.parse(localStorage.getItem('ideas') || '[]');
-const statuses = Object.values(IdeaStatus);
 
 function populateCategories() {
   const ideaSelect = document.getElementById('idea-category');
@@ -29,6 +29,17 @@ function populateStatuses() {
     option.textContent = st;
     filterSelect.appendChild(option);
   });
+}
+
+function loadStatuses() {
+  fetch('data/statuses.json')
+    .then(res => res.json())
+    .then(data => {
+      statuses = data.ideaStatuses || [];
+      populateStatuses();
+      filterIdeas();
+    })
+    .catch(err => console.error('Failed to load statuses', err));
 }
 
 function saveIdeas() {
@@ -90,5 +101,5 @@ function loadCategories() {
 }
 
 loadCategories();
-populateStatuses();
+loadStatuses();
 filterIdeas();

--- a/webapp/js/models.js
+++ b/webapp/js/models.js
@@ -1,11 +1,16 @@
 const IdeaStatus = {
-  SUBMITTED: 'Submitted',
-  IN_REVIEW: 'In Review',
-  IMPLEMENTED: 'Implemented'
+  DRAFT: 'Draft',
+  UNDER_REVIEW: 'UnderReview',
+  ACCEPTED: 'Accepted',
+  IMPLEMENTED: 'Implemented',
+  PARTIALLY_IMPLEMENTED: 'PartialyImplemented',
+  REJECTED: 'Rejected',
+  DEPLOYED: 'Deployed',
+  ALREADY_EXISTS: 'AlreadyExists'
 };
 
 class Idea {
-  constructor(title, description, category, status = IdeaStatus.SUBMITTED) {
+  constructor(title, description, category, status = IdeaStatus.DRAFT) {
     this['@type'] = GI2MO.Idea;
     this.title = title;
     this.description = description;


### PR DESCRIPTION
## Summary
- extract enumeration instances from the GI2MO OWL file
- add script to generate status lists
- expand idea categories
- load statuses dynamically
- extend status enumeration in models

## Testing
- `npm install`
- `node scripts/generate_statuses.cjs`

------
https://chatgpt.com/codex/tasks/task_e_68476e749ed48332afe040ad7a2aaf62