### PR TITLE
Add basic idea comments feature

### DIFF
--- a/webapp/css/style.css
+++ b/webapp/css/style.css
@@ -14,3 +14,24 @@ button { padding: 0.5em 1em; }
   width: auto;
   min-width: 150px;
 }
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hidden { display: none; }
+
+.modal-content {
+  background: #fff;
+  padding: 1em;
+  max-width: 600px;
+  width: 90%;
+}

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -44,6 +44,22 @@
     <ul id="ideas-list"></ul>
   </section>
 
+  <div id="idea-modal" class="modal hidden">
+    <div class="modal-content">
+      <h2 id="modal-title"></h2>
+      <p id="modal-description"></p>
+      <h3>Comments</h3>
+      <ul id="comments-list"></ul>
+      <form id="comment-form">
+        <label>Add Comment
+          <textarea id="comment-text" required></textarea>
+        </label>
+        <button type="submit">Add Comment</button>
+      </form>
+      <button id="close-modal">Close</button>
+    </div>
+  </div>
+
   <script src="js/ontology.js"></script>
   <script src="js/models.js"></script>
   <script src="js/app.js"></script>

--- a/webapp/js/models.js
+++ b/webapp/js/models.js
@@ -17,6 +17,7 @@ class Idea {
     this.category = category;
     this.status = status;
     this.created = new Date().toISOString();
+    this.comments = [];
   }
 }
 
@@ -35,6 +36,15 @@ class Review {
     this['@type'] = GI2MO.Review;
     this.text = text;
     this.score = score;
+    this.author = author;
+    this.created = new Date().toISOString();
+  }
+}
+
+class Comment {
+  constructor(text, author) {
+    this['@type'] = GI2MO.Comment;
+    this.text = text;
     this.author = author;
     this.created = new Date().toISOString();
   }


### PR DESCRIPTION
## Summary
- add modal dialog for viewing idea details and comments
- style modal overlay
- allow storing and displaying comments for each idea
- ensure old ideas have a comments array

## Testing
- `npm run generate:statuses` *(fails: Cannot find module '@xmldom/xmldom')*

------
https://chatgpt.com/codex/tasks/task_e_684830be20388332a55ced5815cdf308